### PR TITLE
Remove incorrect service import

### DIFF
--- a/src/Server/Services/Player/PlayerService.lua
+++ b/src/Server/Services/Player/PlayerService.lua
@@ -16,7 +16,6 @@ local Types = require(ReplicatedStorage.Shared.Modules.Data.Types)
 type ANY_TABLE = Types.ANY_TABLE
 --Module imports (Require)
 local Knit: ANY_TABLE = require(ReplicatedStorage.Packages.Knit)
-local NPCService: ANY_TABLE
 
 local PlayerdataService: ANY_TABLE
 local PlayerService: ANY_TABLE = Knit.CreateService({
@@ -58,7 +57,6 @@ end
 ]=]
 function PlayerService:KnitInit(): nil
 	PlayerdataService = Knit.GetService("PlayerdataService")
-	NPCService = Knit.GetService("NPCService")
 	return nil
 end
 


### PR DESCRIPTION
# Remove incorrect service import
## Pull request standards
Please check if the PR fulfills these requirements
- [x] Changes have been tested and verified to work
- [x] Moonwave markdown added / updated (for bug fixes / features)
- [x] Lua is type-checked (Optional, but highly encouraged! Not necessary to set strict)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR removes a service import under PlayerService that shouldn't have been there to begin with ("NPCService")

## What is the current behavior? (You can also link to an open issue here)
Knit warns in the output about NPCService not existing

## What is the new behavior (if this is a feature change)?
Knit no longer warns in the output about NPCService not existing


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
N/A

## Other information
